### PR TITLE
Fixing secret key env variable

### DIFF
--- a/tests/server-mocks.js
+++ b/tests/server-mocks.js
@@ -40,7 +40,7 @@ const transformedAuth = `createShopifyAuth({
 });`;
 
 const server = `import * as handlers from "./handlers/index";
-const { SHOPIFY_API_SECRET_KEY, SHOPIFY_API_KEY } = process.env;
+const { SHOPIFY_API_SECRET, SHOPIFY_API_KEY } = process.env;
 dotenv.config();
 app.prepare().then(() => {
   const server = new Koa();
@@ -66,7 +66,7 @@ app.prepare().then(() => {
 
 const transformedWithWebhooksandEnv = `import * as handlers from \"./handlers/index\";
 const {
-  SHOPIFY_API_SECRET_KEY,
+  SHOPIFY_API_SECRET,
   SHOPIFY_API_KEY
 } = process.env;
 import { receiveWebhook } from '@shopify/koa-shopify-webhooks';
@@ -76,7 +76,7 @@ app.prepare().then(() => {
   const server = new Koa();
   const router = new Router();
   const webhook = receiveWebhook({
-    secret: SHOPIFY_API_SECRET_KEY
+    secret: SHOPIFY_API_SECRET
   });
 
   server.use(createShopifyAuth({
@@ -108,7 +108,7 @@ app.prepare().then(() => {
 
 const transformedWithMoreWebhooks = `import * as handlers from \"./handlers/index\";
 const {
-  SHOPIFY_API_SECRET_KEY,
+  SHOPIFY_API_SECRET,
   SHOPIFY_API_KEY
 } = process.env;
 import { receiveWebhook } from '@shopify/koa-shopify-webhooks';
@@ -117,7 +117,7 @@ app.prepare().then(() => {
   const server = new Koa();
   const router = new Router();
   const webhook = receiveWebhook({
-    secret: SHOPIFY_API_SECRET_KEY
+    secret: SHOPIFY_API_SECRET
   });
   server.use(createShopifyAuth({
     scopes: [\"read_products\", \"write_products\"],

--- a/webhook/generate-webhook-environment.js
+++ b/webhook/generate-webhook-environment.js
@@ -3,7 +3,7 @@ const traverse = require("@babel/traverse").default;
 const get = require("lodash.get");
 
 const generateWebhookEnvironment = ast => {
-  const code = `const webhook = receiveWebhook({secret: SHOPIFY_API_SECRET_KEY});`;
+  const code = `const webhook = receiveWebhook({secret: SHOPIFY_API_SECRET});`;
   const importPackage = `import { receiveWebhook } from '@shopify/koa-shopify-webhooks';`;
   let webhookDeclaration;
   let routerDeclaration;


### PR DESCRIPTION
This library was still referencing SHOPIFY_API_SECRET_KEY instead of SHOPIFY_API_SECRET. 

fixes: https://github.com/Shopify/shopify-app-cli/issues/427