### PR TITLE
Update template to match new Resource list example

### DIFF
--- a/page/list-template.js
+++ b/page/list-template.js
@@ -6,7 +6,7 @@ const createListTemplate = handle => {
   import { Avatar, Card, Button, ResourceItem, ResourceList, TextStyle, TextField, Filters } from '@shopify/polaris';
 
 
-  export default function ${componentName} {
+  export default function ${componentName}() {
     const [selectedItems, setSelectedItems] = useState([]);
     const [sortValue, setSortValue] = useState('DATE_MODIFIED_DESC');
     const [taggedWith, setTaggedWith] = useState('VIP');

--- a/page/list-template.js
+++ b/page/list-template.js
@@ -2,44 +2,152 @@ const { toPascalCase } = require("../utilities");
 
 const createListTemplate = handle => {
   const componentName = toPascalCase(handle);
-  return `import { Avatar, Card, FilterType, Page, ResourceList, TextStyle } from '@shopify/polaris';
+  return `import React, {useCallback, useState} from 'react';
+  import { Avatar, Card, Button, ResourceItem, ResourceList, TextStyle, TextField, Filters } from '@shopify/polaris';
 
-  export default class ${componentName} extends React.Component {
-    state = {
-      selectedItems: [],
-      sortValue: 'DATE_MODIFIED_DESC',
-      searchValue: '',
-      appliedFilters: [
-        {
-          key: 'accountStatusFilter',
-          value: 'Account enabled',
-        },
-      ],
+
+  export default function ${componentName} {
+    const [selectedItems, setSelectedItems] = useState([]);
+    const [sortValue, setSortValue] = useState('DATE_MODIFIED_DESC');
+    const [taggedWith, setTaggedWith] = useState('VIP');
+    const [queryValue, setQueryValue] = useState(null);
+
+    const handleTaggedWithChange = useCallback(
+      (value) => setTaggedWith(value),
+      [],
+    );
+    const handleQueryValueChange = useCallback(
+      (value) => setQueryValue(value),
+      [],
+    );
+    const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+    const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+    const handleClearAll = useCallback(() => {
+      handleTaggedWithRemove();
+      handleQueryValueRemove();
+    }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+    const resourceName = {
+      singular: 'customer',
+      plural: 'customers',
     };
-    handleSearchChange = (searchValue) => {
-      this.setState({ searchValue });
-    };
-    handleFiltersChange = (appliedFilters) => {
-      this.setState({ appliedFilters });
-    };
-    handleSortChange = (sortValue) => {
-      this.setState({ sortValue });
-    };
-    handleSelectionChange = (selectedItems) => {
-      this.setState({ selectedItems });
-    };
-    renderItem = (item) => {
-      const { id, url, name, location, latestOrderUrl } = item;
+
+    const items = [
+      {
+        id: 341,
+        url: 'customers/341',
+        name: 'Mae Jemison',
+        location: 'Decatur, USA',
+        latestOrderUrl: 'orders/1456',
+      },
+      {
+        id: 256,
+        url: 'customers/256',
+        name: 'Ellen Ochoa',
+        location: 'Los Angeles, USA',
+        latestOrderUrl: 'orders/1457',
+      },
+    ];
+
+    const promotedBulkActions = [
+      {
+        content: 'Edit customers',
+        onAction: () => console.log('Todo: implement bulk edit'),
+      },
+    ];
+
+    const bulkActions = [
+      {
+        content: 'Add tags',
+        onAction: () => console.log('Todo: implement bulk add tags'),
+      },
+      {
+        content: 'Remove tags',
+        onAction: () => console.log('Todo: implement bulk remove tags'),
+      },
+      {
+        content: 'Delete customers',
+        onAction: () => console.log('Todo: implement bulk delete'),
+      },
+    ];
+
+    const filters = [
+      {
+        key: 'taggedWith',
+        label: 'Tagged with',
+        filter: (
+          <TextField
+            label="Tagged with"
+            value={taggedWith}
+            onChange={handleTaggedWithChange}
+            labelHidden
+          />
+        ),
+        shortcut: true,
+      },
+    ];
+
+    const appliedFilters = !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+    const filterControl = (
+      <Filters
+        queryValue={queryValue}
+        filters={filters}
+        appliedFilters={appliedFilters}
+        onQueryChange={handleQueryValueChange}
+        onQueryClear={handleQueryValueRemove}
+        onClearAll={handleClearAll}
+      >
+        <div style={{paddingLeft: '8px'}}>
+          <Button onClick={() => console.log('New filter saved')}>Save</Button>
+        </div>
+      </Filters>
+    );
+
+    return (
+      <Card>
+        <ResourceList
+          resourceName={resourceName}
+          items={items}
+          renderItem={renderItem}
+          selectedItems={selectedItems}
+          onSelectionChange={setSelectedItems}
+          promotedBulkActions={promotedBulkActions}
+          bulkActions={bulkActions}
+          sortValue={sortValue}
+          sortOptions={[
+            {label: 'Newest update', value: 'DATE_MODIFIED_DESC'},
+            {label: 'Oldest update', value: 'DATE_MODIFIED_ASC'},
+          ]}
+          onSortChange={(selected) => {
+            setSortValue(selected);
+            console.log("Sort option changed to " +  selected);
+          }}
+          filterControl={filterControl}
+        />
+      </Card>
+    );
+
+    function renderItem(item) {
+      const {id, url, name, location, latestOrderUrl} = item;
       const media = <Avatar customer size="medium" name={name} />;
       const shortcutActions = latestOrderUrl
-        ? [{ content: 'View latest order', url: latestOrderUrl }]
+        ? [{content: 'View latest order', url: latestOrderUrl}]
         : null;
       return (
-        <ResourceList.Item
+        <ResourceItem
           id={id}
           url={url}
           media={media}
-          accessibilityLabel={'View details for example'}
+          accessibilityLabel={"View details for "  + name}
           shortcutActions={shortcutActions}
           persistActions
         >
@@ -47,104 +155,27 @@ const createListTemplate = handle => {
             <TextStyle variation="strong">{name}</TextStyle>
           </h3>
           <div>{location}</div>
-        </ResourceList.Item>
-      );
-    };
-    render() {
-      const resourceName = {
-        singular: 'customer',
-        plural: 'customers',
-      };
-      const items = [
-        {
-          id: 341,
-          url: 'customers/341',
-          name: 'Mae Jemison',
-          location: 'Decatur, USA',
-          latestOrderUrl: 'orders/1456',
-        },
-        {
-          id: 256,
-          url: 'customers/256',
-          name: 'Ellen Ochoa',
-          location: 'Los Angeles, USA',
-          latestOrderUrl: 'orders/1457',
-        },
-      ];
-      const promotedBulkActions = [
-        {
-          content: 'Edit customers',
-          onAction: () => console.log('Todo: implement bulk edit'),
-        },
-      ];
-      const bulkActions = [
-        {
-          content: 'Add tags',
-          onAction: () => console.log('Todo: implement bulk add tags'),
-        },
-        {
-          content: 'Remove tags',
-          onAction: () => console.log('Todo: implement bulk remove tags'),
-        },
-        {
-          content: 'Delete customers',
-          onAction: () => console.log('Todo: implement bulk delete'),
-        },
-      ];
-      const filters = [
-        {
-          key: 'orderCountFilter',
-          label: 'Number of orders',
-          operatorText: 'is greater than',
-          type: FilterType.TextField,
-        },
-        {
-          key: 'accountStatusFilter',
-          label: 'Account status',
-          operatorText: 'is',
-          type: FilterType.Select,
-          options: ['Enabled', 'Invited', 'Not invited', 'Declined'],
-        },
-      ];
-      const filterControl = (
-        <ResourceList.FilterControl
-          filters={filters}
-          appliedFilters={this.state.appliedFilters}
-          onFiltersChange={this.handleFiltersChange}
-          searchValue={this.state.searchValue}
-          onSearchChange={this.handleSearchChange}
-          additionalAction={{
-            content: 'Save',
-            onAction: () => console.log('New filter saved'),
-          }}
-        />
-      );
-      return (
-        <Page>
-          <Card>
-            <ResourceList
-              resourceName={resourceName}
-              items={items}
-              renderItem={this.renderItem}
-              selectedItems={this.state.selectedItems}
-              onSelectionChange={this.handleSelectionChange}
-              promotedBulkActions={promotedBulkActions}
-              bulkActions={bulkActions}
-              sortValue={this.state.sortValue}
-              sortOptions={[
-                { label: 'Newest update', value: 'DATE_MODIFIED_DESC' },
-                { label: 'Oldest update', value: 'DATE_MODIFIED_ASC' },
-              ]}
-              onSortChange={(selected) => {
-                this.setState({ sortValue: selected });
-              }}
-              filterControl={filterControl}
-            />
-          </Card>
-        </Page>
+        </ResourceItem>
       );
     }
-  };`;
+
+    function disambiguateLabel(key, value) {
+      switch (key) {
+        case 'taggedWith':
+          return "Tagged with "  + value;
+        default:
+          return value;
+      }
+    }
+
+    function isEmpty(value) {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      } else {
+        return value === '' || value == null;
+      }
+    }
+  }`;
 };
 
 module.exports = createListTemplate;


### PR DESCRIPTION
Resolves issues such as https://github.com/Shopify/shopify-app-node/issues/477
I was not able to find a downgraded polaris or react version that would resolve the above issue, so I figured its about time to update the template. 

New template generates a page that looks like:
![image](https://user-images.githubusercontent.com/30154753/104932730-fae09500-5975-11eb-86e4-8230d074ebe1.png)

The old template comes from the [Resource Item readme](https://github.com/Shopify/polaris-react/blob/master/src/components/ResourceList/README.md) example created by https://github.com/Shopify/polaris-react/pull/978, which has since been updated.

The only difference between the updated example in Polaris and this PR is the removal of string interpolation for simple concatenation, since the back quotes interfered with the return statement. 
` console.log(`Sort option changed to ${selected}.`); -> console.log("Sort option changed to " +  selected);`